### PR TITLE
What if i don't have rails?

### DIFF
--- a/serve.gemspec
+++ b/serve.gemspec
@@ -72,16 +72,22 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rack>, [">= 1.2.1"])
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.5"])
+      s.add_runtime_dependency(%q<mongrel>)
+      s.add_runtime_dependency(%q<i18n>)
       s.add_development_dependency(%q<rspec>, [">= 1.2.9"])
     else
       s.add_dependency(%q<rack>, [">= 1.2.1"])
       s.add_dependency(%q<activesupport>, [">= 2.3.5"])
       s.add_dependency(%q<rspec>, [">= 1.2.9"])
+      s.add_dependency(%q<mongrel>)
+      s.add_dependency(%q<il8n>)
     end
   else
     s.add_dependency(%q<rack>, [">= 1.2.1"])
     s.add_dependency(%q<activesupport>, [">= 2.3.5"])
     s.add_dependency(%q<rspec>, [">= 1.2.9"])
+    s.add_dependency(%q<mongrel>)
+    s.add_dependency(%q<il8n>)
   end
 end
 


### PR DESCRIPTION
I realise serve is more than likely to be used alongside rails but after moving over to RVM i find myself setting up a gemset specifically for prototyping. Ideally the gemspec should install all the requirements for getting serve up and running and not relying on rails.

Have amended the gemspec to include the missing gem dependencies:
- Mongrel
- i18n
