### PR TITLE
Add javascript_include_tag and stylesheet_link_tag view helpers

### DIFF
--- a/lib/serve/view_helpers.rb
+++ b/lib/serve/view_helpers.rb
@@ -178,7 +178,7 @@ module Serve #:nodoc:
     end
     
     def image(name, options = {})
-      image_tag(append_image_extension("/images/#{name}"), options)
+      image_tag(ensure_path(ensure_extension(name, 'png'), 'images'), options)
     end
     
     def javascript_tag(content = nil, html_options = {})
@@ -193,8 +193,7 @@ module Serve #:nodoc:
     end
     
     def link_to_function(name, *args, &block)
-      html_options = {}
-      html_options = args.pop if args.last.is_a? Hash
+      html_options = extract_options!(args)
       function = args[0] || ''
       onclick = "#{"#{html_options[:onclick]}; " if html_options[:onclick]}#{function}; return false;"
       href = html_options[:href] || '#'
@@ -320,14 +319,6 @@ module Serve #:nodoc:
             end
           end
           " #{attrs.sort * ' '}" unless attrs.empty?
-        end
-      end
-      
-      def append_image_extension(name)
-        unless name =~ /\.(.*?)$/
-          name + '.png'
-        else
-          name
         end
       end
 


### PR DESCRIPTION
This is a response to [issue #25](https://github.com/jlong/serve/issues/25).

I've added basic implementations of the `javascript_include_tag` and `stylesheet_link_tag` methods as seen in Rails. They have similar functionality where they accept variable arguments, but they do not support `:all` as the first argument to glob a directory of files.
