### PR TITLE
Fixed problem with export that caused filenames with underscore to be excluded

### DIFF
--- a/lib/serve/export.rb
+++ b/lib/serve/export.rb
@@ -41,7 +41,7 @@ module Serve
           files.reject! { |fn| fn =~ /view_helpers.rb$/} # remove view_helpers.rb
           @redirects, @public = files.partition { |fn| fn =~ %r{\.redirect$} }
         end
-        @views.reject! { |v| v =~ %r{_[^\/]+$} }        # remove partials
+        @views.reject! { |v| v =~ /(^_|\/_)/ }           # remove partials
       end
       
       def compile_compass_sass


### PR DESCRIPTION
The regexp for @views.reject actually rejected any view that contained an underscore, not just partials. I modified it so that it only rejects files that start with _ (partials in the site root directory) or files that start with /_ (partials in subfolders).
