### PR TITLE
filename case is breaking new project generation

### DIFF
--- a/lib/serve/project.rb
+++ b/lib/serve/project.rb
@@ -73,7 +73,7 @@ module Serve #:nodoc:
           views
         ).each { |path| make_path path }
         create_file 'config.ru',       read_template('config.ru')
-        create_file 'LICENSE',         read_template('license')
+        create_file 'LICENSE',         read_template('LICENSE')
         create_file '.gitignore',      read_template('gitignore')
         create_file 'compass.config',  read_template('compass.config')
         create_file 'README.markdown', read_template('README.markdown')


### PR DESCRIPTION
 $ serve create server
      exists  server
      exists  server/public
      exists  server/tmp
      exists  server/views
      exists  server/config.ru
/home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/project.rb:117:in `read': No such file or directory - ../../.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/templates/license (Errno::ENOENT)
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/project.rb:117:in`read_template'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/project.rb:76:in `setup_base'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/project.rb:23:in`create'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/project.rb:39:in `create'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/application.rb:23:in`run'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/lib/serve/application.rb:11:in `run'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/gems/serve-1.5.0.pre2/bin/serve:16
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/bin/serve:19:in`load'
    from /home/sid137/.rvm/gems/ruby-1.8.7-p334/bin/serve:19
