### PR TITLE
fix smart quote HTML entity

### DIFF
--- a/website/views/index.html.erb
+++ b/website/views/index.html.erb
@@ -47,7 +47,7 @@
   
   <section>
     <h4>Serve&#8201;+&#8201;Git&#8201;=&#8201;The Perfect CMS</h4>
-    <p>If you use a &#8220;Design First&#8201; workflow for your web apps you
+    <p>If you use a &#8220;Design First&#8221; workflow for your web apps you
       can use Serve to build working HTML prototypes (or mockups) of the finished
       application to test flow and design decisions, before turning it over to
       the developers.</p>


### PR DESCRIPTION
![smart quote issue](http://benatkin.github.com/gh-images/smart-quotes.png)

The closing smart quote on _Design First_ doesn't show up in Chrome, Safari, or Firefox. After investigating I found that the number was one digit off.
