### PR TITLE
Make content_for rails compatible

### DIFF
--- a/lib/serve/view_helpers.rb
+++ b/lib/serve/view_helpers.rb
@@ -35,8 +35,10 @@ module Serve #:nodoc:
   end
   
   module ContentHelpers
-    def content_for(symbol, &block)
-      set_content_for(symbol, capture(&block))
+    def content_for(symbol, content = nil, &block)
+      content = capture(&block) if block_given?
+      set_content_for(symbol, content) if content
+      get_content_for(symbol) unless content
     end
     
     def content_for?(symbol)


### PR DESCRIPTION
I was trying to use some simple rails helpers in a serve project and came across this one.  In rails `content_for` can also retrieve the content if no content is passed (there is no block), you can also set content_for using the `content` param instead of a block.  This changes serve's content_for to mimic that behavior.

``` erb
content_for(:something, 'some string')
content_for(:something) #=> 'some string'
```

I couldn't find a spec for testing the helpers, but i can add one for this change if you can point it out. Works fine in the project(s) I'm working on though.

ps, awesome work on serve!
