### PR TITLE
Fix escaped copyright_years helper output

### DIFF
--- a/lib/serve/templates/default/views/view_helpers.rb
+++ b/lib/serve/templates/default/views/view_helpers.rb
@@ -9,9 +9,9 @@ module ViewHelpers
   def copyright_years(start_year)
     end_year = Date.today.year
     if start_year == end_year
-      "\#{start_year}"
+      "#{start_year}"
     else
-      "\#{start_year}&#8211;\#{end_year}"
+      "#{start_year}&#8211;#{end_year}"
     end
   end
   

--- a/spec/views/view_helpers.rb
+++ b/spec/views/view_helpers.rb
@@ -3,32 +3,32 @@
 # View helpers allow you keep templates clean.
 #
 module ViewHelpers
-  
+
   # Example helper method
   def hello(name)
     "Hello \#{name}!"
   end
-  
+
   # Handy for hiding a block of unfinished code
   def hidden(&block)
     #no-op
   end
-  
+
   # Shorthand for referencing images in the images folder
   def image(name, options = {})
     path = "/images/\#{name}"
     path += ".png" unless path.match(/\.[A-za-z]{3,4}$/)
     image_tag(name, {:alt => ""}.update(options))
   end
-  
+
   # Calculate the years for a copyright
   def copyright_years(start_year)
     end_year = Date.today.year
     if start_year == end_year
-      "\#{start_year}"
+      "#{start_year}"
     else
-      "\#{start_year}&#8211;\#{end_year}"
+      "#{start_year}&#8211;#{end_year}"
     end
   end
-  
+
 end


### PR DESCRIPTION
Figured the result had mistakenly been escaped, so output wasn't  interpolated properly.

[Commit](https://github.com/avocade/serve/commit/8f8840adeff36a7a8335244c4f025ce0797cfb01)

Thanks for an awesome tool!
