### PR TITLE
Tell Ruby 1.9 to treat sass (and other external) files as UTF-8

### DIFF
--- a/website/compass.config
+++ b/website/compass.config
@@ -2,6 +2,8 @@
 # Compass Configuration
 #
 
+Encoding.default_external='UTF-8'
+
 # HTTP paths
 http_path             = '/'
 http_stylesheets_path = '/stylesheets'


### PR DESCRIPTION
This allows the current serve skeleton site to work out of the box with Ruby 1.9.
