### PR TITLE
Use Rack::TryStatic for static public files.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source :rubygems
 
 gem 'rack',              '~> 1.2'
+gem 'rack-contrib'
 gem 'rack-test',         '~> 0.5'
 gem 'tilt',              '~> 1.3'
 gem 'activesupport',     '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     mutter (0.5.3)
     polyglot (0.3.2)
     rack (1.3.2)
+    rack-contrib (1.1.0)
+      rack (>= 0.9.1)
     rack-test (0.6.1)
       rack (>= 1.0)
     radius (0.7.3)
@@ -88,6 +90,7 @@ DEPENDENCIES
   less (~> 1.2.21)
   maruku (~> 0.6.0)
   rack (~> 1.2)
+  rack-contrib
   rack-test (~> 0.5)
   radius (~> 0.7.3)
   rake (~> 0.9.0)

--- a/lib/serve/application.rb
+++ b/lib/serve/application.rb
@@ -267,7 +267,7 @@ module Serve
           use Rack::ShowExceptions
           run Rack::Cascade.new([
             Serve::RackAdapter.new(root),
-            Rack::Directory.new(root)
+            Rack::Directory.new(root),
           ])
         end
         begin


### PR DESCRIPTION
Rack::TryStatic will attempt to load paths from public before
passing them on to serve.

Also has more graceful handling for the case of a missing compass
config file.

Should fix #36, but I'd really appreciate review.
