### PR TITLE
Fixed small typo with generated config.ru file

### DIFF
--- a/website/config.ru
+++ b/website/config.ru
@@ -36,7 +36,7 @@ use Rack::ShowExceptions  # Nice looking errors
 
 # Rack Application
 if ENV['SERVER_SOFTWARE'] =~ /passenger/i
-  # Passendger only needs the adapter
+  # Passenger only needs the adapter
   run Serve::RackAdapter.new(root + '/views')
 else
   # Use Rack::Cascade and Rack::Directory on other platforms for static assets


### PR DESCRIPTION
Hey John. What's up? I just fixed a small typo on the generated config.ru file (Passendger -> Passenger). As I side note, I think that the docs at http://get-serve.com/documentation/coffee-script are a bit wrong. Wouldn't it be "require 'rack-coffee'" instead of "gem 'rack-coffee'" in the config.ru file?

Hope I've helped!

Marcelo Wiermann
