### PR TITLE
Update Gemfile to use https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rack',              '~> 1.2'
 gem 'rack-test',         '~> 0.5'


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
