### PR TITLE
No layout for SASS

### DIFF
--- a/lib/serve/handlers/sass_handler.rb
+++ b/lib/serve/handlers/sass_handler.rb
@@ -28,5 +28,9 @@ module Serve #:nodoc:
     def content_type
       'text/css'
     end
+
+    def layout?
+      false
+    end
   end
 end


### PR DESCRIPTION
Bug fix: serving SASS files shouldn't use a layout; using a layout would incorrectly add HTML headers and footers to the CSS output.
