### PR TITLE
fix routing priority on directory index

### DIFF
--- a/lib/serve/router.rb
+++ b/lib/serve/router.rb
@@ -16,7 +16,7 @@ module Serve
         path
       when File.directory?(best_match(full_path))
         # It's a directory? Try a directory index.
-        resolve(root, File.join(path, 'index'))
+        resolve(root, File.join(path, 'index.')) || resolve(root, File.join(path, 'index'))
       when path =~ /\.css\Z/i
         # CSS not found? Try SCSS or Sass.
         alternates = %w{.scss .sass}.map { |ext| path.sub(/\.css\Z/, ext) }


### PR DESCRIPTION
In original version, `/index-xxx.html` 's priority is higher than `index.html` 's when fetching directory (like `http://your.domain/`). So it may search `index.` first.