### PR TITLE
index.css served as directory index file

### DIFF
--- a/spec/fixtures/directory/index.css
+++ b/spec/fixtures/directory/index.css
@@ -1,0 +1,1 @@
+.a { color: red; }


### PR DESCRIPTION
As described in issues ##122 adding an `index.css` file will fail the following specs:

```
Failed examples:

rspec ./spec/router_spec.rb:23 # Serve::Router should resolve directory indexes
rspec ./spec/router_spec.rb:54 # Serve::Router should resolve directories without case sensitivity
```
