### PR TITLE
Rename bin to exe to match the new Bundler convention

### DIFF
--- a/.document
+++ b/.document
@@ -1,6 +1,6 @@
 README.rdoc
 CHANGELOG.rdoc
 lib/**/*.rb
-bin/*
+exe/*
 features/**/*.feature
 LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ pkg
 .sass-cache/**/*
 test_project/.sass-cache/**/*
 junk/*
-!bin/serve
-bin/*
+!exe/serve
+exe/*

--- a/serve.gemspec
+++ b/serve.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     "README.rdoc",
     "Rakefile",
     "VERSION",
-    "bin/serve",
+    "exe/serve",
     "lib/serve.rb",
     "lib/serve/application.rb",
     "lib/serve/bootstrap/Gemfile",
@@ -162,4 +162,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<coffee-script>, ["~> 2.2.0"])
   end
 end
-

--- a/tasks/jeweler.rake
+++ b/tasks/jeweler.rake
@@ -7,13 +7,13 @@ begin
     gem.email = "me@johnwlong.com"
     gem.homepage = "http://get-serve.com"
     gem.authors = ["John W. Long", "Adam I. Williams", "Robert Evans"]
-    
-    gem.files = FileList["[A-Z]*", "{bin,lib,rails,spec}/**/*"].exclude("tmp")
+
+    gem.files = FileList["[A-Z]*", "{exe,lib,rails,spec}/**/*"].exclude("tmp")
     gem.files << 'lib/serve/templates/blank/.empty'
     gem.files << 'lib/serve/templates/default/public/.htaccess'
 
     gem.license = 'MIT'
-    
+
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
   Jeweler::GemcutterTasks.new

--- a/tasks/website.rake
+++ b/tasks/website.rake
@@ -7,29 +7,29 @@ def ok_failed(condition)
 end
 
 namespace :website do
-  
+
   desc "remove files in output directory"
   task :clean do
     puts "Removing output..."
     Dir["website/output/*"].each { |f| rm_rf(f) }
   end
-  
+
   desc "generate website in output directory"
   task :generate => :clean do
     puts "Generating website..."
-    system "bin/serve export website website/output"
+    system "exe/serve export website website/output"
   end
-  
+
   desc "generate and deploy website"
   task :deploy => :generate do
     print "Deploying website..."
     ok_failed system("rsync -avz --delete --rsync-path=/usr/local/bin/rsync website/output/ wiseheart@wiseheartdesign.com:~/domains/get-serve.com/web/public")
   end
-  
+
   desc "serve website using serve (how meta)"
   task :serve do
     puts "Serving website..."
     system "serve website"
   end
-  
+
 end


### PR DESCRIPTION
* Rename the bin folder and change the Gemspec to reflect that.
* Some rake tasks was using bin/serve, so changed to exe.
* Add a Git ignore entry and update a doc file mentioning bin.

See: http://bundler.io/blog/2015/03/20/moving-bins-to-exe.html